### PR TITLE
Prevent a crash on Android when using a BarcodeScanner

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -85,6 +85,10 @@ var Carousel = (function (_super) {
             if(this.parent instanceof grid_layout.GridLayout){
                 this.parent.android.addView(this._pageIndicatorView, this._pagerIndicatorLayoutParams);
             }else{
+                // will crash the app after fi. a barcodescanner was closed
+                if (this._pageIndicatorView.parent !== null) {
+                  this.parent.android.removeView(this._pageIndicatorView);
+                }
                 this.parent.android.addView(this._pageIndicatorView);
             }
 


### PR DESCRIPTION
In an Angular test app with the Barcode Scanner plugin integrated on the page where also a carousel was shown, the app would crash after closing the scanner.

Will probably crash with any other activity-switching usage as well. This fix prevents that.

And many thanks for the great plugin, I'm using it in one of my projects and I really like it!