### PR TITLE
use grid over absolute for odd positioning on iOS

### DIFF
--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -6,7 +6,7 @@ import {
   removeWeakEventListener
 } from 'tns-core-modules/ui/core/weak-event-listener/weak-event-listener';
 import { Label } from 'tns-core-modules/ui/label';
-import { AbsoluteLayout } from 'tns-core-modules/ui/layouts/absolute-layout/absolute-layout';
+import { GridLayout } from 'tns-core-modules/ui/layouts/grid-layout';
 import { StackLayout } from 'tns-core-modules/ui/layouts/stack-layout';
 import { isNullOrUndefined, isNumber } from 'tns-core-modules/utils/types';
 
@@ -34,7 +34,7 @@ export const CLog = (type: CLogTypes = 0, ...args) => {
   }
 };
 
-export class CarouselCommon extends AbsoluteLayout {
+export class CarouselCommon extends GridLayout {
   /**
    * String value when hooking into the pageChanged event.
    */


### PR DESCRIPTION
@manijak: See following for reasoning.

### Grid extended
![simulator screen shot - iphone 6 - 2018-08-01 at 12 54 03](https://user-images.githubusercontent.com/6006148/43542362-621a724a-9592-11e8-866a-f53f4000bb76.png)

### Absolute extended
![simulator screen shot - iphone 6 - 2018-08-01 at 13 02 20](https://user-images.githubusercontent.com/6006148/43542393-73d4f758-9592-11e8-854a-631c5d4d0b71.png)

Page markup:

```xml
<ActionBar class="action-bar" flat="true" title="Connectivity">
  <NavigationButton android:visibility="collapse"></NavigationButton>
</ActionBar>

<GridLayout tkMainContent rows="*" columns="*" class="page">

  <Carousel #carousel (loaded)="onCarouselLoad()" ios:indicatorOffset="0,-10" ios:finite="true" ios:bounce="false" height="100%"
    indicatorColor="#66ccff" indicatorColorUnselected="#cceeff">
    <CarouselItem *ngFor="let slide of slides">

      <GridLayout rows="auto, *" cols="*">

        <StackLayout row="0" class="topSlide" height="35%">
          <Gif *ngIf="slide.Image.indexOf('.gif') > -1" [src]="slide.Image" (tap)="onGifTap($event)" height="100%" width="135"></Gif>
        </StackLayout>

        <ScrollView row="1" class="lowerSlide" height="65%">
          <StackLayout>
            <Label [text]="slide.Label" class="label" textWrap="true"></Label>
            <Label *ngFor="let bullet of slide.Bullets" [text]="bullet" class="bullet" textWrap="true"></Label>
          </StackLayout>
        </ScrollView>

      </GridLayout>
    </CarouselItem>
  </Carousel>
</GridLayout>
```
Nothing fancy or odd in the template as you can see, I've tried with many different settings of the page/grid doing all the layout changes I could think of 😄 

I've tested the demo app on android/ios and everything works well. Same works within the project I'm using this on. 