### PR TITLE
chore: replace accessing DeviceOrientation from Enums with CoreTypes

### DIFF
--- a/src/carousel.ios.ts
+++ b/src/carousel.ios.ts
@@ -1,4 +1,4 @@
-import { Application, Builder, Enums, Screen, Utils } from '@nativescript/core';
+import { Application, Builder, CoreTypes, Screen, Utils } from '@nativescript/core';
 import {
   autoPagingIntervalProperty,
   bounceProperty,
@@ -27,8 +27,7 @@ export class Carousel extends CarouselCommon {
   constructor() {
     super();
     CarouselUtil.debug = this.debug;
-
-    this.currentOrientation = Enums.DeviceOrientation.unknown;
+    this.currentOrientation = CoreTypes.DeviceOrientation.unknown;
     Application.on('orientationChanged', this.onOrientationChanged);
   }
 


### PR DESCRIPTION
`Enums` is getting deprecated in NS 9.0 and is being replaced with `CoreTypes`: https://github.com/NativeScript/NativeScript/compare/8.0.0-core...8.0.1

