### PR TITLE
Replace compile with implementation as compile is removed in gradle 7

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -2,5 +2,5 @@ android {
     
 }
 dependencies {
-  compile 'com.romandanylyk:pageindicatorview:1.0.3'
+  implementation  'com.romandanylyk:pageindicatorview:1.0.3'
 }


### PR DESCRIPTION
compile is depreciated in gradle 6 but completly removed in gradle 7 this change will make the plugin compatible with gradle 7